### PR TITLE
Adding Retool to Sponsor Page

### DIFF
--- a/src/config/sponsors.ts
+++ b/src/config/sponsors.ts
@@ -614,11 +614,17 @@ export default [
       'https://www.redhat.com/en/command-line-heroes',
     logoUrl: '/static/img/sponsors/clhlogo.png',
   },
-   {
+  {
     name: 'Honeybadger',
     url:
       'https://www.honeybadger.io/?utm_source=reactpodcast_toolsday&utm_medium=email&utm_campaign=podcast',
     logoUrl: '/static/img/sponsors/honeybadgerlogo.png',
+  },
+  {
+    name: 'Retool',
+    url:
+      'https://retool.com/?utm_source=spec&utm_medium=podcast',
+    logoUrl: '/static/img/sponsors/retoollogo.png',
   },
   {
     name: 'TestCafe',


### PR DESCRIPTION
Retool kicks off as the sponsor of Developer Tea on 08/18/2020