### PR TITLE
Adding Deepsource as a sponsor

### DIFF
--- a/src/config/sponsors.ts
+++ b/src/config/sponsors.ts
@@ -632,4 +632,10 @@ export default [
       'https://devexpress.github.io/testcafe/',
     logoUrl: '/static/img/sponsors/testcafelogo.png',
   },
+  {
+    name: 'DeepSource',
+    url:
+      'https://deepsource.io/?ref=devtea',
+    logoUrl: '/static/img/sponsors/deepsource.png',
+  },
 ]


### PR DESCRIPTION
Deepsource to kick off on 09/30/2020