### PR TITLE
Adding Amplify to Sponsor List

### DIFF
--- a/src/config/sponsors.ts
+++ b/src/config/sponsors.ts
@@ -644,4 +644,11 @@ export default [
       'https://curiositystream.com/design',
     logoUrl: '/static/img/sponsors/curiositystreamlogo.png',
   },
+  
+  {
+    name: 'AWS Amplify',
+    url:
+      'https://aws.amazon.com/getting-started/hands-on/build-react-app-amplify-graphql/',
+    logoUrl: '/static/img/sponsors/amplify.png',
+  },
 ]


### PR DESCRIPTION
AWS Amplify is kicking off as a sponsor of React Podcast today :)